### PR TITLE
Define e at outer scope for Python 3

### DIFF
--- a/requestium/requestium.py
+++ b/requestium/requestium.py
@@ -387,6 +387,7 @@ def _ensure_click(self):
               "window.scrollBy(0, elementTop-(viewPortHeight/2));")
     self.parent.execute_script(script, self)  # parent = the webdriver
 
+    e = None  # define e at this level so it does not go out of scope in Python 3
     for _ in range(10):
         try:
             self.click()


### PR DESCRIPTION
flake8 testing of https://github.com/tryolabs/requestium on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./requestium/requestium.py:397:85: F821 undefined name 'e'
        "Couldn't click item after trying 10 times, got error message: \n{}".format(e.message)
                                                                                    ^
```