### PR TITLE
Support customization of `experimental_options` for chrome

### DIFF
--- a/requestium/requestium.py
+++ b/requestium/requestium.py
@@ -114,6 +114,11 @@ class Session(requests.Session):
             prefs = self.webdriver_options['prefs']
             chrome_options.add_experimental_option('prefs', prefs)
 
+        experimental_options = self.webdriver_options.get('experimental_options')
+        if isinstance(experimental_options, dict):
+            for name, value in experimental_options.items():
+                chrome_options.add_experimental_option(name, value)
+
         # Create driver process
         return RequestiumChrome(self.webdriver_path,
                                 options=chrome_options,


### PR DESCRIPTION
Thanks for this great tool which helps me a lot to integrate requests and selenium!

While using chrome webdriver, I usually want to hide `Chrome is being controlled by automated test software` notification. To do so, I should add an experimental option `excludeSwitches` with value `['enable-automation']`:

``` python
options.add_experimental_option('excludeSwitches', ['enable-automation'])
```

But with requestium, there seems no way to set this option now. So I create this PR to let users can provide their own experimental options.
