### PR TITLE
Update parsel dependency version to 1.8

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,10 +16,12 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
-              api.github.com:443
-              api.securityscorecards.dev:443
-              github.com:443
+            api.github.com:443
+            api.securityscorecards.dev:443
+            github.com:443
+            api.deps.dev
+
 
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
 
-      - uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
   "Topic :: Software Development :: Testing",
 ]
 dependencies = [
-    "parsel>=1.7",
+    "parsel>=1.8",
     "requests>=2.27",
     "selenium>=4.32",
     "tldextract>=5.3",

--- a/uv.lock
+++ b/uv.lock
@@ -973,7 +973,7 @@ dev = [
 requires-dist = [
     { name = "bandit", extras = ["sarif"], marker = "extra == 'dev'", specifier = "==1.9.2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.20.0" },
-    { name = "parsel", specifier = ">=1.7" },
+    { name = "parsel", specifier = ">=1.8" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = "~=4.5.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "~=9.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0,<7.2" },


### PR DESCRIPTION
The `lowest-direct` ci tests are failing because parsel 1.7 requires `pkg_resources` but didn't include it in its requirements. As requestium doesn't either, the minimum supported parsel version should be 1.8.

parsel 1.8 release notes:
https://github.com/scrapy/parsel/releases/tag/v1.8.0

I also updated the dependency-review action because it was failing (it was using an old version of the action and missing a new endpoint from the firewall whitelist).